### PR TITLE
feat: add --active-deadline-seconds flag to limit pod lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ helm in-pod exec [FLAGS] -- "COMMAND"
 | `--volume`            |       | Mount volumes in the pod (repeatable). Format: `type:name:mountPath[:ro]`. Types: `pvc`, `secret`, `configmap`, `hostpath` |
 | `--service-account`   |       | Service account for the pod (default: `helm-in-pod`)                         |
 | `--dry-run`           |       | Print the pod spec as YAML without creating anything                         |
+| `--active-deadline-seconds` | | Maximum duration in seconds the pod is allowed to run. Kubernetes terminates the pod once this deadline is exceeded, regardless of whether the client is still connected. Useful to avoid orphaned pods in CI/CD pipelines. `0` means no deadline (default) |
 
 <details>
 <summary>⚠️ <strong>Deprecated Flags</strong></summary>
@@ -501,6 +502,38 @@ helm in-pod daemon start --name dev --dry-run \
   --service-account my-sa \
   --copy-repo
 ```
+
+</details>
+
+### ⏱️ Active Deadline
+
+<details>
+<summary><strong>Prevent orphaned pods in CI/CD pipelines</strong></summary>
+
+When a CI/CD job is cancelled, an SSH session closes, or a machine crashes mid-execution, the pod created by `helm in-pod` may be left running indefinitely. `--active-deadline-seconds` sets a hard time limit enforced by Kubernetes itself — the pod is terminated once the deadline is exceeded, regardless of client connectivity.
+
+```bash
+# Terminate the pod after 30 minutes (1800s) if still running
+helm in-pod exec --active-deadline-seconds 1800 -- "helm upgrade --install myapp repo/chart"
+
+# Use in CI/CD pipeline to protect against hung jobs
+helm in-pod exec \
+  --active-deadline-seconds 3600 \
+  --copy-repo \
+  -- "helm upgrade --install myapp repo/chart -f values.yaml"
+
+# Preview the pod spec with the deadline set
+helm in-pod exec \
+  --dry-run \
+  --active-deadline-seconds 1800 \
+  -- "helm upgrade --install myapp repo/chart"
+
+# Also works with daemon mode
+helm in-pod daemon start --name ci-daemon \
+  --active-deadline-seconds 7200
+```
+
+> **Note**: `--active-deadline-seconds` limits total pod lifetime. For limiting command execution time only, use `--timeout` instead. Both flags can be combined: `--timeout` kills the command while `--active-deadline-seconds` kills the pod.
 
 </details>
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -98,6 +98,7 @@ func addPodCreationFlags(cmd *cobra.Command, opts *cmdoptions.ExecOptions) {
 	cmd.Flags().StringSliceVar(&opts.Volumes, "volume", []string{}, "Mount volumes in the pod. Format: type:name:mountPath[:ro]. Types: pvc, secret, configmap, hostpath. Examples: 'pvc:my-claim:/data', 'secret:my-secret:/etc/creds:ro', 'configmap:my-cm:/etc/config', 'hostpath:/var/log:/host-logs:ro'")
 	cmd.Flags().StringVar(&opts.ServiceAccount, "service-account", "", "Service account to use in the pod (default: helm-in-pod)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Print the pod spec as YAML without creating the pod")
+	cmd.Flags().Int64Var(&opts.ActiveDeadlineSeconds, "active-deadline-seconds", 0, "Maximum duration in seconds the pod is allowed to run. The pod will be terminated by Kubernetes once this deadline is exceeded, regardless of whether the client is still connected. Useful to avoid orphaned pods in CI/CD pipelines. 0 means no deadline (default)")
 }
 
 func addRuntimeFlags(cmd *cobra.Command, opts *cmdoptions.ExecOptions, copyRepoDefault bool) {

--- a/e2e/active_deadline_test.go
+++ b/e2e/active_deadline_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 	"time"
@@ -97,7 +98,7 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			Expect(output).To(ContainSubstring("deadline-ok"))
 		})
 
-		It("should terminate pod when active deadline expires before command completes", func() {
+		It("should terminate pod when active deadline expires before command completes", func(_ context.Context) {
 			start := time.Now()
 			cmd := BuildHelmInPodCommand(
 				"--labels", testLabel,

--- a/e2e/active_deadline_test.go
+++ b/e2e/active_deadline_test.go
@@ -4,8 +4,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/noksa/helm-in-pod/internal/hipconsts"
@@ -29,8 +31,12 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 		logOnFailure(testNS)
 	})
 
-	Context("--dry-run verification", func() {
-		It("should include activeDeadlineSeconds in pod spec when flag is set", func() {
+	// ─────────────────────────────────────────────────────────────────────────
+	// DRY-RUN: spec generation
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("--dry-run spec generation", func() {
+		It("should include activeDeadlineSeconds: 1800 in exec pod spec", func() {
 			cmd := BuildHelmInPodCommand(
 				"--labels", testLabel,
 				"--dry-run",
@@ -42,19 +48,7 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 1800"))
 		})
 
-		It("should not include activeDeadlineSeconds in pod spec when flag is not set (default 0)", func() {
-			cmd := BuildHelmInPodCommand(
-				"--labels", testLabel,
-				"--dry-run",
-				"--", "helm version",
-			)
-			output, exitCode := RunWithExitCode(cmd)
-			Expect(exitCode).To(Equal(0), "output: %s", output)
-			Expect(output).NotTo(ContainSubstring("activeDeadlineSeconds"),
-				"activeDeadlineSeconds should not appear in pod spec when not set")
-		})
-
-		It("should include activeDeadlineSeconds in daemon pod spec when flag is set", func() {
+		It("should include activeDeadlineSeconds: 3600 in daemon pod spec", func() {
 			daemonName := generateReleaseName("deadline-daemon")
 			cmd := BuildDaemonStartCommand(
 				"--name", daemonName,
@@ -68,7 +62,56 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 3600"))
 		})
 
-		It("should not create a pod when dry-run is combined with active-deadline-seconds", func() {
+		It("should include activeDeadlineSeconds: 86400 (1 day) in pod spec", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "86400",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 86400"))
+		})
+
+		It("should include activeDeadlineSeconds: 60 in pod spec", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "60",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 60"))
+		})
+
+		It("should NOT include activeDeadlineSeconds when flag is not passed", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).NotTo(ContainSubstring("activeDeadlineSeconds"),
+				"activeDeadlineSeconds must be absent when not set")
+		})
+
+		It("should NOT include activeDeadlineSeconds when flag is explicitly 0", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "0",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).NotTo(ContainSubstring("activeDeadlineSeconds"),
+				"activeDeadlineSeconds: 0 means no limit — must not appear in spec")
+		})
+
+		It("should not create any real pod during dry-run with active-deadline-seconds", func() {
 			cmd := BuildHelmInPodCommand(
 				"--labels", testLabel,
 				"--dry-run",
@@ -78,16 +121,93 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			output, exitCode := RunWithExitCode(cmd)
 			Expect(exitCode).To(Equal(0), "output: %s", output)
 
-			// Verify no pod was created
-			cmd = exec.Command("kubectl", "get", "pods", "-n", hipconsts.HelmInPodNamespace,
-				"-l", strings.Replace(testLabel, "=", "=", 1), "-o", "name")
+			// parse label key=value for kubectl
+			parts := strings.SplitN(testLabel, "=", 2)
+			Expect(parts).To(HaveLen(2))
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-n", hipconsts.HelmInPodNamespace,
+				"-l", fmt.Sprintf("%s=%s", parts[0], parts[1]),
+				"-o", "name")
 			podOutput, _ := Run(cmd)
-			Expect(strings.TrimSpace(podOutput)).To(BeEmpty(), "No pod should be created in dry-run mode")
+			Expect(strings.TrimSpace(podOutput)).To(BeEmpty(),
+				"dry-run must not create any pod in the cluster")
 		})
 	})
 
-	Context("--active-deadline-seconds runtime enforcement", func() {
-		It("should complete successfully when command finishes before the deadline", func() {
+	// ─────────────────────────────────────────────────────────────────────────
+	// REAL POD: field verification in Kubernetes
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("real pod field verification", func() {
+		// safeDeadlineQuery returns the activeDeadlineSeconds value for the first pod
+		// matching testLabel in HelmInPodNamespace, or "" if no pod exists yet.
+		// Uses range jsonpath so kubectl exits 0 even on empty lists.
+		safeDeadlineQuery := func(lbl string) func() string {
+			return func() string {
+				parts := strings.SplitN(lbl, "=", 2)
+				if len(parts) != 2 {
+					return ""
+				}
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-n", hipconsts.HelmInPodNamespace,
+					"-l", fmt.Sprintf("%s=%s", parts[0], parts[1]),
+					"-o", "jsonpath={range .items[*]}{.spec.activeDeadlineSeconds}{end}")
+				out, _ := RunWithExitCode(cmd)
+				return strings.TrimSpace(out)
+			}
+		}
+
+		It("should set activeDeadlineSeconds in the running pod object", func() {
+			// Run in background so we can inspect the pod while it's alive
+			done := make(chan struct{})
+			var cmdOutput string
+			var cmdExit int
+			go func() {
+				defer close(done)
+				cmd := BuildHelmInPodCommand(
+					"--labels", testLabel,
+					"--active-deadline-seconds", "120",
+					"--", "sleep 30",
+				)
+				cmdOutput, cmdExit = RunWithExitCode(cmd)
+			}()
+
+			// Poll until the pod appears with the expected field (up to 45s)
+			Eventually(safeDeadlineQuery(testLabel),
+				45*time.Second, 3*time.Second,
+			).Should(Equal("120"),
+				"activeDeadlineSeconds must be 120 on the live pod object")
+
+			<-done
+			Expect(cmdExit).To(Equal(0), "pod should complete before 120s deadline, output: %s", cmdOutput)
+		})
+
+		It("should have no activeDeadlineSeconds field when flag is not set", func() {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				cmd := BuildHelmInPodCommand(
+					"--labels", testLabel,
+					"--", "sleep 20",
+				)
+				_, _ = RunWithExitCode(cmd)
+			}()
+
+			// Wait for the pod to be scheduled, then verify the field is absent
+			time.Sleep(18 * time.Second)
+			Expect(safeDeadlineQuery(testLabel)()).To(BeEmpty(),
+				"activeDeadlineSeconds must be absent when flag is not set")
+
+			<-done
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// RUNTIME ENFORCEMENT
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("runtime enforcement", func() {
+		It("should complete successfully when command finishes well before the deadline", func() {
 			cmd := BuildHelmInPodCommand(
 				"--labels", testLabel,
 				"--active-deadline-seconds", "300",
@@ -96,6 +216,30 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			output, exitCode := RunWithExitCode(cmd)
 			Expect(exitCode).To(Equal(0), "output: %s", output)
 			Expect(output).To(ContainSubstring("deadline-ok"))
+		})
+
+		It("should preserve full stdout output when command completes before deadline", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--active-deadline-seconds", "300",
+				"--", "echo line1; echo line2; echo line3",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("line1"))
+			Expect(output).To(ContainSubstring("line2"))
+			Expect(output).To(ContainSubstring("line3"))
+		})
+
+		It("should propagate non-zero exit code when command itself fails before deadline", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--active-deadline-seconds", "300",
+				"--", "exit 42",
+			)
+			_, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(42),
+				"exit code from the command must be preserved")
 		})
 
 		It("should terminate pod when active deadline expires before command completes", func(_ context.Context) {
@@ -109,12 +253,276 @@ var _ = Describe("Active Deadline Seconds Flag", func() {
 			output, exitCode := RunWithExitCode(cmd)
 			elapsed := time.Since(start)
 
-			// Pod must be terminated (non-zero exit), not run for full sleep duration
 			Expect(exitCode).NotTo(Equal(0),
-				"Pod should be terminated by Kubernetes deadline, output: %s", output)
-			// Should terminate well before the sleep command would finish
+				"pod must be terminated by Kubernetes deadline, output: %s", output)
 			Expect(elapsed).To(BeNumerically("<", 3*time.Minute),
-				"Pod should be terminated by deadline, not run for full duration")
+				"should terminate well before sleep 300 finishes")
+		}, NodeTimeout(5*time.Minute))
+
+		It("should terminate faster with short deadline than with a long timeout", func(_ context.Context) {
+			// Baseline: same command but large deadline → must run longer
+			longStart := time.Now()
+			cmdLong := BuildHelmInPodCommand(
+				"--labels", generateTestLabel(),
+				"--active-deadline-seconds", "300",
+				"--timeout", "5m",
+				"--", "sleep 15",
+			)
+			_, longExit := RunWithExitCode(cmdLong)
+			longElapsed := time.Since(longStart)
+
+			// Short deadline: pod must be killed sooner
+			shortStart := time.Now()
+			cmdShort := BuildHelmInPodCommand(
+				"--labels", generateTestLabel(),
+				"--active-deadline-seconds", "5",
+				"--timeout", "2m",
+				"--", "sleep 300",
+			)
+			_, shortExit := RunWithExitCode(cmdShort)
+			shortElapsed := time.Since(shortStart)
+
+			Expect(longExit).To(Equal(0), "long-deadline command should complete")
+			Expect(shortExit).NotTo(Equal(0), "short-deadline command must be killed")
+			Expect(shortElapsed).To(BeNumerically("<", longElapsed+60*time.Second),
+				"short-deadline pod should be killed quickly")
+		}, NodeTimeout(8*time.Minute))
+	})
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// CONCURRENT EXECUTION: isolation
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("concurrent executions with different deadlines", func() {
+		It("should handle multiple concurrent exec pods with independent deadlines", func(_ context.Context) {
+			type result struct {
+				label    string
+				exitCode int
+				output   string
+				elapsed  time.Duration
+			}
+
+			var mu sync.Mutex
+			var wg sync.WaitGroup
+			results := make([]result, 3)
+
+			// Pod 0: short deadline (dies)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				label := generateTestLabel()
+				start := time.Now()
+				cmd := BuildHelmInPodCommand(
+					"--labels", label,
+					"--active-deadline-seconds", "5",
+					"--timeout", "2m",
+					"--", "sleep 300",
+				)
+				out, code := RunWithExitCode(cmd)
+				mu.Lock()
+				results[0] = result{label, code, out, time.Since(start)}
+				mu.Unlock()
+			}()
+
+			// Pod 1: generous deadline (completes)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				label := generateTestLabel()
+				start := time.Now()
+				cmd := BuildHelmInPodCommand(
+					"--labels", label,
+					"--active-deadline-seconds", "300",
+					"--", "echo concurrent-ok",
+				)
+				out, code := RunWithExitCode(cmd)
+				mu.Lock()
+				results[1] = result{label, code, out, time.Since(start)}
+				mu.Unlock()
+			}()
+
+			// Pod 2: no deadline (completes normally)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				label := generateTestLabel()
+				start := time.Now()
+				cmd := BuildHelmInPodCommand(
+					"--labels", label,
+					"--", "echo no-deadline-ok",
+				)
+				out, code := RunWithExitCode(cmd)
+				mu.Lock()
+				results[2] = result{label, code, out, time.Since(start)}
+				mu.Unlock()
+			}()
+
+			wg.Wait()
+
+			// Pod 0: killed by deadline
+			Expect(results[0].exitCode).NotTo(Equal(0),
+				"short-deadline pod must be killed, output: %s", results[0].output)
+			Expect(results[0].elapsed).To(BeNumerically("<", 3*time.Minute),
+				"short-deadline pod must die well before sleep 300")
+
+			// Pod 1: completes with output
+			Expect(results[1].exitCode).To(Equal(0),
+				"generous-deadline pod must succeed, output: %s", results[1].output)
+			Expect(results[1].output).To(ContainSubstring("concurrent-ok"))
+
+			// Pod 2: no deadline, completes normally
+			Expect(results[2].exitCode).To(Equal(0),
+				"no-deadline pod must succeed, output: %s", results[2].output)
+			Expect(results[2].output).To(ContainSubstring("no-deadline-ok"))
+		}, NodeTimeout(8*time.Minute))
+	})
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// DAEMON POD: real creation
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("daemon pod with active-deadline-seconds", func() {
+		var daemonName string
+
+		AfterEach(func() {
+			if daemonName != "" {
+				cmd := exec.Command("helm", "in-pod", "daemon", "stop",
+					"--name", daemonName, "-n", testNS)
+				_, _ = Run(cmd)
+			}
+		})
+
+		It("should start a daemon pod and expose activeDeadlineSeconds in its live spec", func() {
+			daemonName = generateReleaseName("dl-daemon")
+			cmd := BuildDaemonStartCommand(
+				"--name", daemonName,
+				"--labels", testLabel,
+				"--active-deadline-seconds", "600",
+				"-n", testNS,
+			)
+			output, err := Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "daemon start failed: %s", output)
+
+			// Daemon pods always live in the helm-in-pod namespace, named "daemon-<name>"
+			podName := fmt.Sprintf("daemon-%s", daemonName)
+			cmd = exec.Command("kubectl", "get", "pod", podName,
+				"-n", hipconsts.HelmInPodNamespace,
+				"-o", "jsonpath={.spec.activeDeadlineSeconds}")
+			podOutput, err := Run(cmd)
+			Expect(err).NotTo(HaveOccurred(),
+				"failed to query daemon pod %s in ns %s", podName, hipconsts.HelmInPodNamespace)
+			Expect(strings.TrimSpace(podOutput)).To(Equal("600"),
+				"daemon pod must have activeDeadlineSeconds=600 in its live spec")
+		})
+
+		It("should allow daemon exec to complete successfully before the daemon deadline", func() {
+			daemonName = generateReleaseName("dl-exec-daemon")
+			cmd := BuildDaemonStartCommand(
+				"--name", daemonName,
+				"--labels", testLabel,
+				"--active-deadline-seconds", "300",
+				"-n", testNS,
+			)
+			output, err := Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "daemon start failed: %s", output)
+
+			cmd = exec.Command("helm", "in-pod", "daemon", "exec",
+				"--name", daemonName,
+				"-n", testNS,
+				"--", "echo daemon-deadline-exec-ok")
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("daemon-deadline-exec-ok"))
+		})
+
+		It("should start a daemon pod without activeDeadlineSeconds when flag is not set", func() {
+			daemonName = generateReleaseName("dl-nodl-daemon")
+			cmd := BuildDaemonStartCommand(
+				"--name", daemonName,
+				"--labels", testLabel,
+				"-n", testNS,
+			)
+			output, err := Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "daemon start failed: %s", output)
+
+			// Daemon pods always live in the helm-in-pod namespace, named "daemon-<name>"
+			// Field absent → empty string returned, kubectl exits 0 for a specific pod
+			podName := fmt.Sprintf("daemon-%s", daemonName)
+			cmd = exec.Command("kubectl", "get", "pod", podName,
+				"-n", hipconsts.HelmInPodNamespace,
+				"-o", "jsonpath={.spec.activeDeadlineSeconds}")
+			podOutput, err := Run(cmd)
+			Expect(err).NotTo(HaveOccurred(),
+				"failed to query daemon pod %s in ns %s", podName, hipconsts.HelmInPodNamespace)
+			Expect(strings.TrimSpace(podOutput)).To(BeEmpty(),
+				"daemon pod must NOT have activeDeadlineSeconds when flag is not set")
+		})
+	})
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// INTERACTION: combined flags
+	// ─────────────────────────────────────────────────────────────────────────
+
+	Context("interaction with other flags", func() {
+		It("should respect --active-deadline-seconds alongside custom --labels", func() {
+			extraLabel := generateTestLabel()
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--labels", extraLabel,
+				"--active-deadline-seconds", "300",
+				"--", "echo labels-and-deadline-ok",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("labels-and-deadline-ok"))
+		})
+
+		It("should apply activeDeadlineSeconds to each exec pod independently when run sequentially", func() {
+			for i := 0; i < 3; i++ {
+				lbl := generateTestLabel()
+				cmd := BuildHelmInPodCommand(
+					"--labels", lbl,
+					"--active-deadline-seconds", "300",
+					"--", fmt.Sprintf("echo seq-run-%d", i),
+				)
+				output, exitCode := RunWithExitCode(cmd)
+				Expect(exitCode).To(Equal(0), "run %d failed, output: %s", i, output)
+				Expect(output).To(ContainSubstring(fmt.Sprintf("seq-run-%d", i)))
+			}
+		})
+
+		It("should coexist correctly with --timeout when deadline is longer than timeout", func(_ context.Context) {
+			// timeout=10s, deadline=120s → timeout fires first
+			start := time.Now()
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--timeout", "10s",
+				"--active-deadline-seconds", "120",
+				"--", "sleep 300",
+			)
+			_, exitCode := RunWithExitCode(cmd)
+			elapsed := time.Since(start)
+
+			Expect(exitCode).NotTo(Equal(0), "should fail due to --timeout")
+			Expect(elapsed).To(BeNumerically("<", 3*time.Minute),
+				"--timeout should fire before the longer deadline")
+		}, NodeTimeout(5*time.Minute))
+
+		It("should coexist correctly with --timeout when deadline is shorter than timeout", func(_ context.Context) {
+			// deadline=5s, timeout=2m → deadline fires first
+			start := time.Now()
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--timeout", "2m",
+				"--active-deadline-seconds", "5",
+				"--", "sleep 300",
+			)
+			_, exitCode := RunWithExitCode(cmd)
+			elapsed := time.Since(start)
+
+			Expect(exitCode).NotTo(Equal(0), "should fail due to deadline")
+			Expect(elapsed).To(BeNumerically("<", 2*time.Minute),
+				"deadline should fire before the longer --timeout")
 		}, NodeTimeout(5*time.Minute))
 	})
 })

--- a/e2e/active_deadline_test.go
+++ b/e2e/active_deadline_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/noksa/helm-in-pod/internal/hipconsts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Active Deadline Seconds Flag", func() {
+	var (
+		testNS    string
+		testLabel string
+	)
+
+	BeforeEach(func() {
+		testNS = createNamespace("e2e-deadline")
+		testLabel = generateTestLabel()
+		DeferCleanup(func() { deleteNamespace(testNS) })
+	})
+
+	AfterEach(func() {
+		logOnFailure(testNS)
+	})
+
+	Context("--dry-run verification", func() {
+		It("should include activeDeadlineSeconds in pod spec when flag is set", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "1800",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 1800"))
+		})
+
+		It("should not include activeDeadlineSeconds in pod spec when flag is not set (default 0)", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).NotTo(ContainSubstring("activeDeadlineSeconds"),
+				"activeDeadlineSeconds should not appear in pod spec when not set")
+		})
+
+		It("should include activeDeadlineSeconds in daemon pod spec when flag is set", func() {
+			daemonName := generateReleaseName("deadline-daemon")
+			cmd := BuildDaemonStartCommand(
+				"--name", daemonName,
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "3600",
+				"-n", testNS,
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("activeDeadlineSeconds: 3600"))
+		})
+
+		It("should not create a pod when dry-run is combined with active-deadline-seconds", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--dry-run",
+				"--active-deadline-seconds", "60",
+				"--", "helm version",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+
+			// Verify no pod was created
+			cmd = exec.Command("kubectl", "get", "pods", "-n", hipconsts.HelmInPodNamespace,
+				"-l", strings.Replace(testLabel, "=", "=", 1), "-o", "name")
+			podOutput, _ := Run(cmd)
+			Expect(strings.TrimSpace(podOutput)).To(BeEmpty(), "No pod should be created in dry-run mode")
+		})
+	})
+
+	Context("--active-deadline-seconds runtime enforcement", func() {
+		It("should complete successfully when command finishes before the deadline", func() {
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--active-deadline-seconds", "300",
+				"--", "echo deadline-ok",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			Expect(exitCode).To(Equal(0), "output: %s", output)
+			Expect(output).To(ContainSubstring("deadline-ok"))
+		})
+
+		It("should terminate pod when active deadline expires before command completes", func() {
+			start := time.Now()
+			cmd := BuildHelmInPodCommand(
+				"--labels", testLabel,
+				"--active-deadline-seconds", "5",
+				"--timeout", "2m",
+				"--", "sleep 300",
+			)
+			output, exitCode := RunWithExitCode(cmd)
+			elapsed := time.Since(start)
+
+			// Pod must be terminated (non-zero exit), not run for full sleep duration
+			Expect(exitCode).NotTo(Equal(0),
+				"Pod should be terminated by Kubernetes deadline, output: %s", output)
+			// Should terminate well before the sleep command would finish
+			Expect(elapsed).To(BeNumerically("<", 3*time.Minute),
+				"Pod should be terminated by deadline, not run for full duration")
+		}, NodeTimeout(5*time.Minute))
+	})
+})

--- a/internal/cmdoptions/exec.go
+++ b/internal/cmdoptions/exec.go
@@ -35,10 +35,11 @@ type ExecOptions struct {
 	Timeout            time.Duration
 	CopyAttempts       int
 	UpdateRepoAttempts int
-	Volumes            []string
-	ServiceAccount     string
-	DryRun             bool
-	CopyFrom           []string
+	Volumes               []string
+	ServiceAccount        string
+	DryRun                bool
+	CopyFrom              []string
+	ActiveDeadlineSeconds int64
 }
 
 // ParseFileMappings parses the Files slice into FilesAsMap.

--- a/internal/hippod/spec.go
+++ b/internal/hippod/spec.go
@@ -222,6 +222,10 @@ func buildPodSpec(opts cmdoptions.ExecOptions, daemon bool) (corev1.PodSpec, err
 		podSpec.HostNetwork = true
 	}
 
+	if opts.ActiveDeadlineSeconds > 0 {
+		podSpec.ActiveDeadlineSeconds = gopointer.NewOf(opts.ActiveDeadlineSeconds)
+	}
+
 	return podSpec, nil
 }
 

--- a/internal/hippod/spec_test.go
+++ b/internal/hippod/spec_test.go
@@ -629,6 +629,80 @@ var _ = Describe("buildDaemonPodSpec", func() {
 	})
 })
 
+var _ = Describe("activeDeadlineSeconds", func() {
+	var baseOpts func() cmdoptions.ExecOptions
+
+	BeforeEach(func() {
+		baseOpts = func() cmdoptions.ExecOptions {
+			return cmdoptions.ExecOptions{
+				Image:         "docker.io/noksa/kubectl-helm:latest",
+				PullPolicy:    "IfNotPresent",
+				CpuRequest:    "500m",
+				CpuLimit:      "1000m",
+				MemoryRequest: "256Mi",
+				MemoryLimit:   "512Mi",
+				RunAsUser:     -1,
+				RunAsGroup:    -1,
+				Timeout:       10 * time.Minute,
+			}
+		}
+	})
+
+	Context("buildPodSpec", func() {
+		It("should not set ActiveDeadlineSeconds when value is 0 (default)", func() {
+			opts := baseOpts()
+			opts.ActiveDeadlineSeconds = 0
+			spec, err := buildPodSpec(opts, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).To(BeNil())
+		})
+
+		It("should set ActiveDeadlineSeconds when a positive value is provided", func() {
+			opts := baseOpts()
+			opts.ActiveDeadlineSeconds = 1800
+			spec, err := buildPodSpec(opts, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*spec.ActiveDeadlineSeconds).To(Equal(int64(1800)))
+		})
+
+		It("should set ActiveDeadlineSeconds to 1 (minimum positive value)", func() {
+			opts := baseOpts()
+			opts.ActiveDeadlineSeconds = 1
+			spec, err := buildPodSpec(opts, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*spec.ActiveDeadlineSeconds).To(Equal(int64(1)))
+		})
+
+		It("should not set ActiveDeadlineSeconds when value is negative", func() {
+			opts := baseOpts()
+			opts.ActiveDeadlineSeconds = -1
+			spec, err := buildPodSpec(opts, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).To(BeNil())
+		})
+	})
+
+	Context("buildDaemonPodSpec", func() {
+		It("should propagate ActiveDeadlineSeconds to daemon pods", func() {
+			opts := baseOpts()
+			opts.ActiveDeadlineSeconds = 3600
+			spec, err := buildDaemonPodSpec(opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*spec.ActiveDeadlineSeconds).To(Equal(int64(3600)))
+		})
+
+		It("should not set ActiveDeadlineSeconds on daemon pod when not specified", func() {
+			opts := baseOpts()
+			spec, err := buildDaemonPodSpec(opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.ActiveDeadlineSeconds).To(BeNil())
+		})
+	})
+})
+
 // --- helpers ---
 
 func envVarNames(envs []corev1.EnvVar) []string {


### PR DESCRIPTION
## Related Issue

Closes #7

## What this PR does

Adds a new `--active-deadline-seconds` flag that sets the Kubernetes `PodSpec.ActiveDeadlineSeconds` field. When configured, Kubernetes terminates the pod server-side after the specified duration, regardless of client connectivity.

This solves the orphaned pod problem that occurs when CI/CD jobs are cancelled, SSH sessions close, or machines crash mid-execution.

## Key design decisions

- **`0` means disabled** (default) — no behavior change for existing deployments
- **Server-side enforcement** — unlike `--timeout` (client-side), this is enforced by Kubernetes itself; the pod is terminated even if the client disconnects
- **Works for both exec and daemon pods** — `buildPodSpec()` is shared, so both modes benefit automatically
- **Conditional** — field is only added to the PodSpec when `ActiveDeadlineSeconds > 0`, keeping the spec clean

## Difference from `--timeout`

| Flag | Enforcement | Survives disconnect? |
|------|------------|----------------------|
| `--timeout` | Client-side | No — if client dies, pod runs forever |
| `--active-deadline-seconds` | Server-side (Kubernetes) | Yes — pod is always terminated after deadline |

Both can be combined: `--timeout` for client waiting, `--active-deadline-seconds` as a safety net.

## Changes

| File | Change |
|------|--------|
| `internal/cmdoptions/exec.go` | Add `ActiveDeadlineSeconds int64` field to `ExecOptions` |
| `cmd/flags.go` | Register `--active-deadline-seconds` in `addPodCreationFlags()` |
| `internal/hippod/spec.go` | Set `podSpec.ActiveDeadlineSeconds` when value `> 0` |
| `internal/hippod/spec_test.go` | 6 unit tests (zero/positive/negative/daemon cases) |
| `e2e/active_deadline_test.go` | E2e tests: dry-run verification + runtime enforcement |
| `README.md` | Flag table entry + dedicated usage section with examples |

## Testing

**Unit tests** — 126/126 pass:
```
go test ./internal/hippod/... 
ok  github.com/noksa/helm-in-pod/internal/hippod  0.744s
```

**Dry-run verified locally** (field present/absent as expected):
```bash
helm in-pod exec --dry-run --active-deadline-seconds 1800 -- helm version
# → activeDeadlineSeconds: 1800 ✓

helm in-pod exec --dry-run -- helm version
# → no activeDeadlineSeconds field ✓
```

**Runtime enforcement on GKE 1.34** — pod running `sleep 300` was terminated by Kubernetes after 8 seconds when `--active-deadline-seconds 8` was set. Total elapsed time: ~12s (vs 300s without the flag).

## Usage

```bash
# Basic usage — terminate pod after 30 minutes
helm in-pod exec --active-deadline-seconds 1800 -- "helm upgrade --install myapp repo/chart"

# CI/CD pipeline pattern
helm in-pod exec \
  --active-deadline-seconds 3600 \
  --copy-repo \
  -- "helm upgrade --install myapp repo/chart -f values.yaml"

# Combined with --timeout
helm in-pod exec \
  --timeout 25m \
  --active-deadline-seconds 1800 \
  -- "helm upgrade --install myapp repo/chart"
```