### PR TITLE
fix: eliminate data race and goroutine leak in signal handler

### DIFF
--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -37,7 +38,7 @@ const Namespace = "helm-in-pod"
 type Manager struct {
 	ctx         context.Context
 	myHostname  string
-	interrupted bool
+	interrupted atomic.Bool
 }
 
 func NewManager(ctx context.Context, hostname string) *Manager {
@@ -128,11 +129,21 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 		}
 	}
 
-	// Handle interrupt signals
+	// Handle interrupt signals. done is closed when CreateHelmPod returns so
+	// the goroutine exits promptly and does not leak across invocations.
+	done := make(chan struct{})
+	defer close(done)
+
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(c)
+
 	go func() {
-		<-c
+		select {
+		case <-done:
+			return
+		case <-c:
+		}
 		if pod != nil && pod.Name != "" {
 			logz.Host().Warn().Msg("Interrupted! Destroying helm pod")
 			destroyErr := m.DeleteHelmPods(opts, cmdoptions.PurgeOptions{All: false})
@@ -143,10 +154,14 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 			if opts.CreatePDB {
 				_ = m.DeletePodDisruptionBudgets(m.ctx, operationID)
 			}
-			m.interrupted = true
+			m.interrupted.Store(true)
 		}
-		<-c
-		os.Exit(1)
+		select {
+		case <-done:
+			return
+		case <-c:
+			os.Exit(1)
+		}
 	}()
 
 	logz.Host().Debug().Msgf("%v pod has been created", color.MagentaString(pod.Name))
@@ -157,7 +172,7 @@ func (m *Manager) waitUntilPodIsRunning(pod *corev1.Pod) error {
 	logz.Host().Info().Msgf("Waiting until %v pod is ready", color.MagentaString(pod.Name))
 
 	err := wait.PollUntilContextTimeout(m.ctx, time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if m.interrupted {
+		if m.interrupted.Load() {
 			return false, fmt.Errorf("interrupted while was waiting for pod readiness")
 		}
 
@@ -182,7 +197,7 @@ func (m *Manager) waitUntilPodIsDeleted(podName string) error {
 	logz.Host().Debug().Msgf("Waiting for pod %v to be deleted", color.CyanString(podName))
 
 	err := wait.PollUntilContextTimeout(m.ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if m.interrupted {
+		if m.interrupted.Load() {
 			return false, fmt.Errorf("interrupted while waiting for pod deletion")
 		}
 


### PR DESCRIPTION
## Problem

`Manager` in `internal/hippod/pod.go` held an `interrupted bool` field that was written from a goroutine watching OS signals and read from the main execution path. This is a data race — both accesses happen concurrently without any synchronization.

Additionally, the signal-watching goroutine started in `CreateHelmPod` was never stopped. Every call to `CreateHelmPod` leaked one goroutine.

## Fix

**Race condition**: Replace `interrupted bool` with `interrupted atomic.Bool` (`sync/atomic`). All writes use `.Store(true)` and all reads use `.Load()`, making concurrent access safe without a mutex.

**Goroutine leak**: Introduce a `done := make(chan struct{})` closed via `defer close(done)` at the start of `CreateHelmPod`. The goroutine selects on both the OS signal channel and `done`, exiting cleanly when the parent function returns. `signal.Stop(c)` is also deferred so no further signals are delivered to the closed channel after cleanup.

## Verification

```
go test ./internal/... -race -count=1  →  all pass, no race reported
go vet ./...                           →  clean
```