### PR TITLE
fix: replace resource.MustParse with ParseQuantity to avoid panics on invalid input

### DIFF
--- a/internal/hippod/spec.go
+++ b/internal/hippod/spec.go
@@ -123,16 +123,32 @@ func buildPodSpec(opts cmdoptions.ExecOptions, daemon bool) (corev1.PodSpec, err
 	limits := corev1.ResourceList{}
 
 	if opts.CpuRequest != "" && opts.CpuRequest != "0" {
-		requests["cpu"] = resource.MustParse(opts.CpuRequest)
+		q, err := resource.ParseQuantity(opts.CpuRequest)
+		if err != nil {
+			return corev1.PodSpec{}, fmt.Errorf("invalid --cpu-request %q: %w", opts.CpuRequest, err)
+		}
+		requests["cpu"] = q
 	}
 	if opts.CpuLimit != "" && opts.CpuLimit != "0" {
-		limits["cpu"] = resource.MustParse(opts.CpuLimit)
+		q, err := resource.ParseQuantity(opts.CpuLimit)
+		if err != nil {
+			return corev1.PodSpec{}, fmt.Errorf("invalid --cpu-limit %q: %w", opts.CpuLimit, err)
+		}
+		limits["cpu"] = q
 	}
 	if opts.MemoryRequest != "" && opts.MemoryRequest != "0" {
-		requests["memory"] = resource.MustParse(opts.MemoryRequest)
+		q, err := resource.ParseQuantity(opts.MemoryRequest)
+		if err != nil {
+			return corev1.PodSpec{}, fmt.Errorf("invalid --memory-request %q: %w", opts.MemoryRequest, err)
+		}
+		requests["memory"] = q
 	}
 	if opts.MemoryLimit != "" && opts.MemoryLimit != "0" {
-		limits["memory"] = resource.MustParse(opts.MemoryLimit)
+		q, err := resource.ParseQuantity(opts.MemoryLimit)
+		if err != nil {
+			return corev1.PodSpec{}, fmt.Errorf("invalid --memory-limit %q: %w", opts.MemoryLimit, err)
+		}
+		limits["memory"] = q
 	}
 
 	securityContext := &corev1.SecurityContext{}

--- a/internal/hippod/spec_test.go
+++ b/internal/hippod/spec_test.go
@@ -210,6 +210,42 @@ var _ = Describe("buildPodSpec", func() {
 			Expect(res.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("1Gi")))
 			Expect(res.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("2Gi")))
 		})
+
+		It("should return an error for invalid --cpu-request instead of panicking", func() {
+			opts := baseOpts()
+			opts.CpuRequest = "badvalue"
+			_, err := buildPodSpec(opts, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--cpu-request"))
+			Expect(err.Error()).To(ContainSubstring("badvalue"))
+		})
+
+		It("should return an error for invalid --cpu-limit instead of panicking", func() {
+			opts := baseOpts()
+			opts.CpuLimit = "not-a-quantity"
+			_, err := buildPodSpec(opts, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--cpu-limit"))
+			Expect(err.Error()).To(ContainSubstring("not-a-quantity"))
+		})
+
+		It("should return an error for invalid --memory-request instead of panicking", func() {
+			opts := baseOpts()
+			opts.MemoryRequest = "5ZZZ"
+			_, err := buildPodSpec(opts, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--memory-request"))
+			Expect(err.Error()).To(ContainSubstring("5ZZZ"))
+		})
+
+		It("should return an error for invalid --memory-limit instead of panicking", func() {
+			opts := baseOpts()
+			opts.MemoryLimit = "xyz"
+			_, err := buildPodSpec(opts, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--memory-limit"))
+			Expect(err.Error()).To(ContainSubstring("xyz"))
+		})
 	})
 
 	Context("security context", func() {


### PR DESCRIPTION
## Problem

`buildPodSpec` in `internal/hippod/spec.go` used `resource.MustParse()` for all four CPU/memory resource values (`--cpu-request`, `--cpu-limit`, `--memory-request`, `--memory-limit`). `MustParse` panics when given an invalid quantity string, so a user typo such as `--cpu-request=badvalue` crashes the entire process with a raw Go stack trace rather than a user-friendly error message.

## Fix

Replace all four `resource.MustParse()` calls with `resource.ParseQuantity()`, which returns `(resource.Quantity, error)`. The error is propagated up from `buildPodSpec` with a clear message that names the flag and the invalid value:

```
invalid --cpu-request "badvalue": quantities must match the regular expression ...
```

## Tests

Four new unit tests in `spec_test.go` — one per flag — confirm that passing an invalid quantity returns a descriptive error instead of panicking:

```
go test ./internal/hippod/... -race -count=1  →  124/124 passed
go vet ./...                                  →  clean
```