### PR TITLE
fix: replace panic with error return in InitManagers for kubeconfig failures

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/fatih/color"
@@ -35,7 +36,9 @@ func newRootCmd() *cobra.Command {
 		if !helpers.IsCompletionCmd(cmd) {
 			logz.Host().Info().Msgf("Running %v command", color.CyanString(cmd.Name()))
 		}
-		internal.InitManagers()
+		if err := internal.InitManagers(); err != nil {
+			return fmt.Errorf("could not initialise Kubernetes client: %w", err)
+		}
 		return nil
 	}
 	rootCmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/vars.go
+++ b/internal/vars.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/Noksa/operator-home/pkg/operatorkclient"
@@ -25,14 +26,14 @@ func buildConfigOverrides() *clientcmd.ConfigOverrides {
 	return overrides
 }
 
-func InitManagers() {
+func InitManagers() error {
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		buildConfigOverrides(),
 	)
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
 	operatorkclient.SetDefaultConfig(config)
@@ -42,6 +43,7 @@ func InitManagers() {
 
 	namespace = hipns.NewManager(ctx)
 	pod = hippod.NewManager(ctx, hostname)
+	return nil
 }
 
 func Namespace() *hipns.Manager {


### PR DESCRIPTION
## Problem

`InitManagers()` in `internal/vars.go` called `panic(err)` when the Kubernetes client configuration could not be loaded — for example when the `KUBECONFIG` path does not exist, the file is malformed, or the cluster is unreachable at config load time. This crashed the entire process with a raw Go stack trace, giving the user no actionable information:

```
goroutine 1 [running]:
github.com/noksa/helm-in-pod/internal.InitManagers(...)
        internal/vars.go:35 +0x...
```

## Fix

Change `InitManagers()` to return `error`. The kubeconfig load error is wrapped with a descriptive prefix and returned:

```go
return fmt.Errorf("failed to load kubeconfig: %w", err)
```

The `PersistentPreRunE` hook in `cmd/root.go` now handles the returned error and wraps it with additional context before Cobra prints it:

```
Error: could not initialise Kubernetes client: failed to load kubeconfig: ...
```

The result is a clean exit-code-1 failure with a readable, single-line error message.

## Verification

```
KUBECONFIG=/tmp/nonexistent go run . exec -- helm version
# Before: panic stack trace
# After:  Error: could not initialise Kubernetes client: failed to load kubeconfig: ...

go test ./internal/... -race -count=1  →  all pass
go vet ./...                           →  clean
```