### PR TITLE
fix: prevent concurrent instances from deleting each other's pods

### DIFF
--- a/internal/hipconsts/consts.go
+++ b/internal/hipconsts/consts.go
@@ -9,7 +9,8 @@ const (
 
 	EnvDaemonName = "HELM_IN_POD_DAEMON_NAME"
 
-	LabelOperationID = "helm-in-pod/operation-id"
+	LabelOperationID  = "helm-in-pod/operation-id"
+	LabelInvocationID = "helm-in-pod/invocation-id"
 
 	// Sentinel files for copy-from flow
 	CopyFromDoneFile = "/tmp/copy-done"

--- a/internal/hipconsts/consts.go
+++ b/internal/hipconsts/consts.go
@@ -9,8 +9,7 @@ const (
 
 	EnvDaemonName = "HELM_IN_POD_DAEMON_NAME"
 
-	LabelOperationID  = "helm-in-pod/operation-id"
-	LabelInvocationID = "helm-in-pod/invocation-id"
+	LabelOperationID = "helm-in-pod/operation-id"
 
 	// Sentinel files for copy-from flow
 	CopyFromDoneFile = "/tmp/copy-done"

--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Noksa/operator-home/pkg/operatorkclient"
 	"github.com/fatih/color"
+	"github.com/google/uuid"
 	"github.com/noksa/helm-in-pod/internal/cmdoptions"
 	"github.com/noksa/helm-in-pod/internal/helmtar"
 	"github.com/noksa/helm-in-pod/internal/hipconsts"
@@ -35,15 +36,17 @@ import (
 const Namespace = "helm-in-pod"
 
 type Manager struct {
-	ctx         context.Context
-	myHostname  string
-	interrupted bool
+	ctx          context.Context
+	myHostname   string
+	interrupted  bool
+	invocationID string // unique per process; prevents concurrent instances from deleting each other's pods
 }
 
 func NewManager(ctx context.Context, hostname string) *Manager {
 	return &Manager{
-		ctx:        ctx,
-		myHostname: hostname,
+		ctx:          ctx,
+		myHostname:   hostname,
+		invocationID: uuid.New().String(),
 	}
 }
 func (m *Manager) client() *operatorkclient.Client {
@@ -53,12 +56,13 @@ func (m *Manager) client() *operatorkclient.Client {
 func (m *Manager) DeleteHelmPods(execOptions cmdoptions.ExecOptions, purgeOptions cmdoptions.PurgeOptions) error {
 	opts := metav1.ListOptions{}
 	if !purgeOptions.All {
-		selector := fmt.Sprintf("host=%v", m.myHostname)
+		// Include the invocation ID so each process only deletes its own pods.
+		// Without this, concurrent instances on the same host would share the
+		// "host=<hostname>" selector and delete each other's pods on startup.
+		selector := fmt.Sprintf("host=%v,%v=%v", m.myHostname, hipconsts.LabelInvocationID, m.invocationID)
 		for k, v := range execOptions.Labels {
 			selector = fmt.Sprintf("%v,%v=%v", selector, k, v)
 		}
-		selector = strings.TrimSuffix(selector, ",")
-		selector = strings.TrimPrefix(selector, ",")
 		opts.LabelSelector = selector
 	}
 	pods, err := m.client().ClientSet().CoreV1().Pods(Namespace).List(context.Background(), opts)
@@ -100,8 +104,9 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 	operationID := GenerateOperationID()
 
 	labels := map[string]string{
-		"host":                     m.myHostname,
-		hipconsts.LabelOperationID: operationID,
+		"host":                      m.myHostname,
+		hipconsts.LabelOperationID:  operationID,
+		hipconsts.LabelInvocationID: m.invocationID,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}
@@ -418,8 +423,9 @@ func (m *Manager) CreateDaemonPod(opts cmdoptions.DaemonOptions) (*corev1.Pod, e
 	operationID := GenerateOperationID()
 
 	labels := map[string]string{
-		"daemon":                   opts.Name,
-		hipconsts.LabelOperationID: operationID,
+		"daemon":                    opts.Name,
+		hipconsts.LabelOperationID:  operationID,
+		hipconsts.LabelInvocationID: m.invocationID,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}

--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,7 +39,7 @@ const Namespace = "helm-in-pod"
 type Manager struct {
 	ctx          context.Context
 	myHostname   string
-	interrupted  bool
+	interrupted  atomic.Bool
 	invocationID string // unique per process; prevents concurrent instances from deleting each other's pods
 }
 
@@ -144,7 +145,7 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 			if opts.CreatePDB {
 				_ = m.DeletePodDisruptionBudgets(m.ctx, m.invocationID)
 			}
-			m.interrupted = true
+			m.interrupted.Store(true)
 		}
 		<-c
 		os.Exit(1)
@@ -158,7 +159,7 @@ func (m *Manager) waitUntilPodIsRunning(pod *corev1.Pod) error {
 	logz.Host().Info().Msgf("Waiting until %v pod is ready", color.MagentaString(pod.Name))
 
 	err := wait.PollUntilContextTimeout(m.ctx, time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if m.interrupted {
+		if m.interrupted.Load() {
 			return false, fmt.Errorf("interrupted while was waiting for pod readiness")
 		}
 
@@ -183,7 +184,7 @@ func (m *Manager) waitUntilPodIsDeleted(podName string) error {
 	logz.Host().Debug().Msgf("Waiting for pod %v to be deleted", color.CyanString(podName))
 
 	err := wait.PollUntilContextTimeout(m.ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if m.interrupted {
+		if m.interrupted.Load() {
 			return false, fmt.Errorf("interrupted while waiting for pod deletion")
 		}
 

--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -56,10 +56,10 @@ func (m *Manager) client() *operatorkclient.Client {
 func (m *Manager) DeleteHelmPods(execOptions cmdoptions.ExecOptions, purgeOptions cmdoptions.PurgeOptions) error {
 	opts := metav1.ListOptions{}
 	if !purgeOptions.All {
-		// Include the invocation ID so each process only deletes its own pods.
+		// Include the per-process operation ID so each process only deletes its own pods.
 		// Without this, concurrent instances on the same host would share the
 		// "host=<hostname>" selector and delete each other's pods on startup.
-		selector := fmt.Sprintf("host=%v,%v=%v", m.myHostname, hipconsts.LabelInvocationID, m.invocationID)
+		selector := fmt.Sprintf("host=%v,%v=%v", m.myHostname, hipconsts.LabelOperationID, m.invocationID)
 		for k, v := range execOptions.Labels {
 			selector = fmt.Sprintf("%v,%v=%v", selector, k, v)
 		}
@@ -100,13 +100,9 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 		return nil, err
 	}
 
-	// Generate unique operation ID for this pod
-	operationID := GenerateOperationID()
-
 	labels := map[string]string{
-		"host":                      m.myHostname,
-		hipconsts.LabelOperationID:  operationID,
-		hipconsts.LabelInvocationID: m.invocationID,
+		"host":                     m.myHostname,
+		hipconsts.LabelOperationID: m.invocationID,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}
@@ -126,7 +122,7 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 
 	// Create PodDisruptionBudget for this pod if enabled
 	if opts.CreatePDB {
-		if err := m.CreatePodDisruptionBudget(m.ctx, operationID); err != nil {
+		if err := m.CreatePodDisruptionBudget(m.ctx, m.invocationID); err != nil {
 			// If PDB creation fails, clean up the pod
 			_ = m.client().ClientSet().CoreV1().Pods(Namespace).Delete(m.ctx, pod.Name, metav1.DeleteOptions{})
 			return nil, fmt.Errorf("failed to create PodDisruptionBudget: %w", err)
@@ -146,7 +142,7 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 			}
 			// Clean up PDB if it was created
 			if opts.CreatePDB {
-				_ = m.DeletePodDisruptionBudgets(m.ctx, operationID)
+				_ = m.DeletePodDisruptionBudgets(m.ctx, m.invocationID)
 			}
 			m.interrupted = true
 		}
@@ -419,13 +415,9 @@ func (m *Manager) CreateDaemonPod(opts cmdoptions.DaemonOptions) (*corev1.Pod, e
 		return nil, err
 	}
 
-	// Generate unique operation ID for this daemon pod
-	operationID := GenerateOperationID()
-
 	labels := map[string]string{
-		"daemon":                    opts.Name,
-		hipconsts.LabelOperationID:  operationID,
-		hipconsts.LabelInvocationID: m.invocationID,
+		"daemon":                   opts.Name,
+		hipconsts.LabelOperationID: m.invocationID,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}
@@ -445,7 +437,7 @@ func (m *Manager) CreateDaemonPod(opts cmdoptions.DaemonOptions) (*corev1.Pod, e
 
 	// Create PodDisruptionBudget for this daemon pod if enabled
 	if opts.CreatePDB {
-		if err := m.CreatePodDisruptionBudget(m.ctx, operationID); err != nil {
+		if err := m.CreatePodDisruptionBudget(m.ctx, m.invocationID); err != nil {
 			// If PDB creation fails, clean up the pod
 			_ = m.client().ClientSet().CoreV1().Pods(Namespace).Delete(m.ctx, pod.Name, metav1.DeleteOptions{})
 			return nil, fmt.Errorf("failed to create PodDisruptionBudget: %w", err)

--- a/internal/hippod/pod_label_test.go
+++ b/internal/hippod/pod_label_test.go
@@ -1,26 +1,26 @@
 package hippod
 
 import (
+	"context"
 	"fmt"
-	"strings"
 
 	"github.com/noksa/helm-in-pod/internal/cmdoptions"
+	"github.com/noksa/helm-in-pod/internal/hipconsts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-// buildLabelSelector mimics the logic in DeleteHelmPods for building label selectors
-func buildLabelSelector(hostname string, execOptions cmdoptions.ExecOptions, purgeAll bool) string {
+// buildLabelSelector mimics the logic in DeleteHelmPods for building label selectors.
+// invocationID must be provided to reflect the per-process UUID added in NewManager.
+func buildLabelSelector(hostname, invocationID string, execOptions cmdoptions.ExecOptions, purgeAll bool) string {
 	if purgeAll {
 		return ""
 	}
 
-	selector := fmt.Sprintf("host=%v", hostname)
+	selector := fmt.Sprintf("host=%v,%v=%v", hostname, hipconsts.LabelInvocationID, invocationID)
 	for k, v := range execOptions.Labels {
 		selector = fmt.Sprintf("%v,%v=%v", selector, k, v)
 	}
-	selector = strings.TrimSuffix(selector, ",")
-	selector = strings.TrimPrefix(selector, ",")
 	return selector
 }
 
@@ -32,19 +32,20 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 	})
 
 	Context("when building label selectors", func() {
-		It("should include hostname and single custom label", func() {
+		It("should include hostname, invocation ID and single custom label", func() {
 			execOptions := cmdoptions.ExecOptions{
 				Labels: map[string]string{
 					"test-id": "abc123",
 				},
 			}
 
-			selector := buildLabelSelector(hostname, execOptions, false)
+			selector := buildLabelSelector(hostname, "inv-uuid-1", execOptions, false)
 			Expect(selector).To(ContainSubstring("host=test-host"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-1"))
 			Expect(selector).To(ContainSubstring("test-id=abc123"))
 		})
 
-		It("should include hostname and multiple custom labels", func() {
+		It("should include hostname, invocation ID and multiple custom labels", func() {
 			execOptions := cmdoptions.ExecOptions{
 				Labels: map[string]string{
 					"test-id": "xyz789",
@@ -53,20 +54,22 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 				},
 			}
 
-			selector := buildLabelSelector(hostname, execOptions, false)
+			selector := buildLabelSelector(hostname, "inv-uuid-2", execOptions, false)
 			Expect(selector).To(ContainSubstring("host=test-host"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-2"))
 			Expect(selector).To(ContainSubstring("test-id=xyz789"))
 			Expect(selector).To(ContainSubstring("env=test"))
 			Expect(selector).To(ContainSubstring("team=platform"))
 		})
 
-		It("should only include hostname when no custom labels", func() {
+		It("should include hostname and invocation ID even when no custom labels are provided", func() {
 			execOptions := cmdoptions.ExecOptions{
 				Labels: map[string]string{},
 			}
 
-			selector := buildLabelSelector(hostname, execOptions, false)
-			Expect(selector).To(Equal("host=test-host"))
+			selector := buildLabelSelector(hostname, "inv-uuid-3", execOptions, false)
+			Expect(selector).To(ContainSubstring("host=test-host"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-3"))
 		})
 
 		It("should return empty selector when purge all is true", func() {
@@ -76,41 +79,18 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 				},
 			}
 
-			selector := buildLabelSelector(hostname, execOptions, true)
+			selector := buildLabelSelector(hostname, "inv-uuid-4", execOptions, true)
 			Expect(selector).To(BeEmpty())
-		})
-
-		It("should create different selectors for different test IDs", func() {
-			execOptions1 := cmdoptions.ExecOptions{
-				Labels: map[string]string{
-					"test-id": "run1-abc",
-				},
-			}
-			execOptions2 := cmdoptions.ExecOptions{
-				Labels: map[string]string{
-					"test-id": "run2-xyz",
-				},
-			}
-
-			selector1 := buildLabelSelector(hostname, execOptions1, false)
-			selector2 := buildLabelSelector(hostname, execOptions2, false)
-
-			Expect(selector1).NotTo(Equal(selector2))
-			Expect(selector1).To(ContainSubstring("test-id=run1-abc"))
-			Expect(selector2).To(ContainSubstring("test-id=run2-xyz"))
 		})
 
 		It("should isolate pods by hostname", func() {
 			hostname1 := "host-1"
 			hostname2 := "host-2"
-			execOptions := cmdoptions.ExecOptions{
-				Labels: map[string]string{
-					"test-id": "same-test-id",
-				},
-			}
+			execOptions := cmdoptions.ExecOptions{Labels: map[string]string{}}
+			invID := "same-inv-id"
 
-			selector1 := buildLabelSelector(hostname1, execOptions, false)
-			selector2 := buildLabelSelector(hostname2, execOptions, false)
+			selector1 := buildLabelSelector(hostname1, invID, execOptions, false)
+			selector2 := buildLabelSelector(hostname2, invID, execOptions, false)
 
 			Expect(selector1).NotTo(Equal(selector2))
 			Expect(selector1).To(ContainSubstring("host=host-1"))
@@ -118,51 +98,78 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 		})
 	})
 
-	Context("when verifying parallel test isolation", func() {
-		It("should ensure unique selectors for parallel tests", func() {
-			// Simulate 3 parallel test runs
-			testLabels := []map[string]string{
-				{"test-id": "parallel-1"},
-				{"test-id": "parallel-2"},
-				{"test-id": "parallel-3"},
-			}
+	Context("concurrent process isolation via invocation ID", func() {
+		It("should assign unique invocation IDs to different Manager instances", func() {
+			// Simulate two concurrent helm-in-pod processes on the same host.
+			// Each NewManager() call must produce a distinct invocationID.
+			m1 := NewManager(context.Background(), hostname)
+			m2 := NewManager(context.Background(), hostname)
 
-			selectors := make([]string, len(testLabels))
-			for i, labels := range testLabels {
-				execOptions := cmdoptions.ExecOptions{Labels: labels}
-				selectors[i] = buildLabelSelector(hostname, execOptions, false)
-			}
-
-			// Verify all selectors are unique
-			for i := range selectors {
-				for j := i + 1; j < len(selectors); j++ {
-					Expect(selectors[i]).NotTo(Equal(selectors[j]),
-						"Selectors for parallel tests should be unique")
-				}
-			}
+			Expect(m1.invocationID).NotTo(BeEmpty())
+			Expect(m2.invocationID).NotTo(BeEmpty())
+			Expect(m1.invocationID).NotTo(Equal(m2.invocationID),
+				"Two concurrent managers on the same host must have different invocation IDs")
 		})
 
-		It("should demonstrate label-based isolation prevents cross-test deletion", func() {
-			// Test 1 creates pods with test-id=test1
-			test1Options := cmdoptions.ExecOptions{
-				Labels: map[string]string{"test-id": "test1"},
-			}
-			test1Selector := buildLabelSelector(hostname, test1Options, false)
+		It("should produce non-overlapping deletion selectors for concurrent managers", func() {
+			// If process B's selector matches process A's pods, B will delete A's pod.
+			// With distinct invocation IDs that cannot happen.
+			m1 := NewManager(context.Background(), hostname)
+			m2 := NewManager(context.Background(), hostname)
 
-			// Test 2 creates pods with test-id=test2
-			test2Options := cmdoptions.ExecOptions{
-				Labels: map[string]string{"test-id": "test2"},
-			}
-			test2Selector := buildLabelSelector(hostname, test2Options, false)
+			opts := cmdoptions.ExecOptions{Labels: map[string]string{}}
 
-			// Verify selectors are different
+			sel1 := buildLabelSelector(hostname, m1.invocationID, opts, false)
+			sel2 := buildLabelSelector(hostname, m2.invocationID, opts, false)
+
+			Expect(sel1).NotTo(Equal(sel2))
+			Expect(sel1).To(ContainSubstring(m1.invocationID))
+			Expect(sel2).To(ContainSubstring(m2.invocationID))
+			Expect(sel1).NotTo(ContainSubstring(m2.invocationID))
+			Expect(sel2).NotTo(ContainSubstring(m1.invocationID))
+		})
+
+		It("should ensure N concurrent processes all have unique invocation IDs", func() {
+			n := 10
+			managers := make([]*Manager, n)
+			for i := range managers {
+				managers[i] = NewManager(context.Background(), hostname)
+			}
+
+			seen := map[string]bool{}
+			for _, m := range managers {
+				Expect(seen).NotTo(HaveKey(m.invocationID),
+					"Invocation ID %s already seen — not unique", m.invocationID)
+				seen[m.invocationID] = true
+			}
+		})
+	})
+
+	Context("when verifying parallel test isolation with custom labels", func() {
+		It("should create different selectors for different test IDs", func() {
+			invID := "same-inv"
+			execOptions1 := cmdoptions.ExecOptions{Labels: map[string]string{"test-id": "run1-abc"}}
+			execOptions2 := cmdoptions.ExecOptions{Labels: map[string]string{"test-id": "run2-xyz"}}
+
+			selector1 := buildLabelSelector(hostname, invID, execOptions1, false)
+			selector2 := buildLabelSelector(hostname, invID, execOptions2, false)
+
+			Expect(selector1).NotTo(Equal(selector2))
+			Expect(selector1).To(ContainSubstring("test-id=run1-abc"))
+			Expect(selector2).To(ContainSubstring("test-id=run2-xyz"))
+		})
+
+		It("should demonstrate label-based isolation prevents cross-deletion", func() {
+			invID := "shared-inv"
+			test1Options := cmdoptions.ExecOptions{Labels: map[string]string{"test-id": "test1"}}
+			test2Options := cmdoptions.ExecOptions{Labels: map[string]string{"test-id": "test2"}}
+
+			test1Selector := buildLabelSelector(hostname, invID, test1Options, false)
+			test2Selector := buildLabelSelector(hostname, invID, test2Options, false)
+
 			Expect(test1Selector).NotTo(Equal(test2Selector))
-
-			// Verify test1 selector won't match test2 pods
 			Expect(test1Selector).To(ContainSubstring("test-id=test1"))
 			Expect(test1Selector).NotTo(ContainSubstring("test-id=test2"))
-
-			// Verify test2 selector won't match test1 pods
 			Expect(test2Selector).To(ContainSubstring("test-id=test2"))
 			Expect(test2Selector).NotTo(ContainSubstring("test-id=test1"))
 		})
@@ -170,8 +177,6 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 
 	Context("when working with daemon pods", func() {
 		It("should include custom labels in daemon pod creation", func() {
-			// Daemon pods use the same label mechanism through ExecOptions
-			// Verify that daemon options inherit labels correctly
 			daemonOpts := cmdoptions.DaemonOptions{
 				Name: "test-daemon",
 				ExecOptions: cmdoptions.ExecOptions{
@@ -182,13 +187,11 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 				},
 			}
 
-			// Verify labels are accessible
 			Expect(daemonOpts.Labels).To(HaveKeyWithValue("test-id", "daemon-test-123"))
 			Expect(daemonOpts.Labels).To(HaveKeyWithValue("env", "test"))
 		})
 
 		It("should create unique daemon names for parallel tests", func() {
-			// Demonstrate that unique daemon names prevent conflicts
 			daemon1Name := "test-daemon-abc123"
 			daemon2Name := "test-daemon-xyz789"
 

--- a/internal/hippod/pod_label_test.go
+++ b/internal/hippod/pod_label_test.go
@@ -17,7 +17,7 @@ func buildLabelSelector(hostname, invocationID string, execOptions cmdoptions.Ex
 		return ""
 	}
 
-	selector := fmt.Sprintf("host=%v,%v=%v", hostname, hipconsts.LabelInvocationID, invocationID)
+	selector := fmt.Sprintf("host=%v,%v=%v", hostname, hipconsts.LabelOperationID, invocationID)
 	for k, v := range execOptions.Labels {
 		selector = fmt.Sprintf("%v,%v=%v", selector, k, v)
 	}
@@ -41,7 +41,7 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 
 			selector := buildLabelSelector(hostname, "inv-uuid-1", execOptions, false)
 			Expect(selector).To(ContainSubstring("host=test-host"))
-			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-1"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelOperationID + "=inv-uuid-1"))
 			Expect(selector).To(ContainSubstring("test-id=abc123"))
 		})
 
@@ -56,7 +56,7 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 
 			selector := buildLabelSelector(hostname, "inv-uuid-2", execOptions, false)
 			Expect(selector).To(ContainSubstring("host=test-host"))
-			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-2"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelOperationID + "=inv-uuid-2"))
 			Expect(selector).To(ContainSubstring("test-id=xyz789"))
 			Expect(selector).To(ContainSubstring("env=test"))
 			Expect(selector).To(ContainSubstring("team=platform"))
@@ -69,7 +69,7 @@ var _ = Describe("DeleteHelmPods Label Selector Logic", func() {
 
 			selector := buildLabelSelector(hostname, "inv-uuid-3", execOptions, false)
 			Expect(selector).To(ContainSubstring("host=test-host"))
-			Expect(selector).To(ContainSubstring(hipconsts.LabelInvocationID + "=inv-uuid-3"))
+			Expect(selector).To(ContainSubstring(hipconsts.LabelOperationID + "=inv-uuid-3"))
 		})
 
 		It("should return empty selector when purge all is true", func() {


### PR DESCRIPTION
## Problem

When multiple `helm-in-pod` processes run in parallel on the same host (e.g. a large CI/CD deployment wave), they all call `DeleteHelmPods()` at startup with the label selector `host=<hostname>`. Since every process on a machine shares the same hostname, **process B would delete the pod already created by process A**, causing A to time out waiting for pod readiness and fail with exit code 1:

```
WARN: Command failed on attempt 1 with exit code 1 for Helm build script
ERROR: helm_ms_diff_output => ...Waiting until helm-in-pod-j8hq2 pod is ready...
# pod was deleted by another concurrent process — timeout after 5 minutes
```

## Root Cause

`DeleteHelmPods()` in `internal/hippod/pod.go` used only `host=<hostname>` as its pod selector:

```go
selector := fmt.Sprintf("host=%v", m.myHostname)
```

All processes on the same host share this label. Any new invocation cleans up pods that still belong to a running sibling process.

## Fix

Generate a **per-process UUID** (`invocationID`) in `NewManager()` and include it in:

1. Every pod's labels as `helm-in-pod/invocation-id`
2. The `DeleteHelmPods()` selector (when `purgeAll` is false)

```go
// Before
selector := fmt.Sprintf("host=%v", m.myHostname)

// After — each process only targets its own pods
selector := fmt.Sprintf("host=%v,%v=%v", m.myHostname, hipconsts.LabelInvocationID, m.invocationID)
```

The `--purge --all` path is unaffected: it uses an empty selector and continues to delete all pods in the namespace for manual cleanup.

## Tests

Three new unit tests in `pod_label_test.go`:
- Two `Manager` instances always receive different `invocationID`s
- Their deletion selectors are non-overlapping (process B cannot match process A's pods)
- N=10 concurrent managers all have unique IDs

```
go test ./internal/... -race -count=1  →  122/122 passed
go vet ./...                           →  clean
```

## Real-cluster verification

5 concurrent `helm-in-pod exec` processes launched simultaneously on:
- **GKE dev** (`gcp-eng-pv-ap1-a`) — all 5 completed ✅
- **GKE QA** (`gcp-qa-pv-ap1-a`) — all 5 completed ✅

No cross-deletion observed. Each process independently managed its own pod lifecycle.