### PR TITLE
feat: add TopologySpreadConstraints to distribute pods across nodes

### DIFF
--- a/internal/hipconsts/consts.go
+++ b/internal/hipconsts/consts.go
@@ -10,6 +10,7 @@ const (
 	EnvDaemonName = "HELM_IN_POD_DAEMON_NAME"
 
 	LabelOperationID = "helm-in-pod/operation-id"
+	LabelManagedBy   = "app.kubernetes.io/managed-by"
 
 	// Sentinel files for copy-from flow
 	CopyFromDoneFile = "/tmp/copy-done"

--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -102,6 +102,7 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 	labels := map[string]string{
 		"host":                     m.myHostname,
 		hipconsts.LabelOperationID: operationID,
+		hipconsts.LabelManagedBy:   Namespace,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}
@@ -420,6 +421,7 @@ func (m *Manager) CreateDaemonPod(opts cmdoptions.DaemonOptions) (*corev1.Pod, e
 	labels := map[string]string{
 		"daemon":                   opts.Name,
 		hipconsts.LabelOperationID: operationID,
+		hipconsts.LabelManagedBy:   Namespace,
 	}
 	maps.Copy(labels, opts.Labels)
 	annotations := map[string]string{}
@@ -549,7 +551,8 @@ func (m *Manager) PrintPodSpecYAML(opts cmdoptions.ExecOptions, isDaemon bool) e
 			GenerateName: fmt.Sprintf("%v-", Namespace),
 			Namespace:    Namespace,
 			Labels: map[string]string{
-				"host": m.myHostname,
+				"host":                   m.myHostname,
+				hipconsts.LabelManagedBy: Namespace,
 			},
 			Annotations: maps.Clone(opts.Annotations),
 		},

--- a/internal/hippod/spec.go
+++ b/internal/hippod/spec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/noksa/helm-in-pod/internal/hipembedded"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // parseVolume parses a volume string in format: type:name:mountPath[:readOnly]
@@ -240,6 +241,22 @@ func buildPodSpec(opts cmdoptions.ExecOptions, daemon bool) (corev1.PodSpec, err
 
 	if opts.ActiveDeadlineSeconds > 0 {
 		podSpec.ActiveDeadlineSeconds = gopointer.NewOf(opts.ActiveDeadlineSeconds)
+	}
+
+	// Spread ephemeral pods across nodes to avoid concentrating kubelet API
+	// calls on a single node, which reduces NodeRestriction admission denials
+	// caused by the NodeAuthorizer graph lag on high-throughput CI/CD clusters.
+	podSpec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					hipconsts.LabelManagedBy: Namespace,
+				},
+			},
+		},
 	}
 
 	return podSpec, nil


### PR DESCRIPTION
## Problem

In high-throughput CI/CD environments where many `helm-in-pod exec` invocations run simultaneously, the Kubernetes scheduler tends to place all ephemeral pods on the same node or a small set of nodes. This concentrates a large number of pod creation and deletion events on those nodes' kubelets, which amplifies a known race in the NodeAuthorizer:

```
User "system:node:<node-name>" cannot get resource "pods" in API group ""
in the namespace "helm-in-pod":
no relationship found between node '<node-name>' and this object
```

The NodeAuthorizer maintains an in-memory graph of node↔pod relationships populated asynchronously. When hundreds of pods land on a single node, the denied GETs flood the audit log and trigger security alerts.

## Fix

Add a soft `TopologySpreadConstraint` (`WhenUnsatisfiable: ScheduleAnyway`) on `kubernetes.io/hostname` with `MaxSkew=1` to every pod spec built by `buildPodSpec`.

`ScheduleAnyway` is intentional: the constraint is a hint, not a hard requirement. Single-node clusters (dev, CI kind) keep working normally without errors.

A new constant `LabelManagedBy` (`app.kubernetes.io/managed-by`) is introduced so the spread constraint has a stable label selector. All pod types (ephemeral exec, daemon, dry-run) receive this label set to `helm-in-pod`.

## Files changed

- `internal/hipconsts/consts.go` — new `LabelManagedBy` constant
- `internal/hippod/pod.go` — add `managed-by` label to all pod creation paths
- `internal/hippod/spec.go` — add `TopologySpreadConstraints` in `buildPodSpec`

## Verification

```
go build ./...                         →  clean
go vet ./...                           →  clean
go test ./internal/... -race -count=1  →  all pass, no race reported
```

E2E tests against a multi-node GKE cluster confirmed that concurrent pods are distributed across nodes and the `managed-by` label is present on all pod types.
