### PR TITLE
fix: check pod readiness via API instead of exec to cut API server load

### DIFF
--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -184,6 +184,23 @@ func (m *Manager) CreateHelmPod(opts cmdoptions.ExecOptions) (*corev1.Pod, error
 	return pod, m.waitUntilPodIsRunning(pod)
 }
 
+// isPodReady reports whether at least one of the pod's containers is marked
+// Ready by the kubelet. The kubelet flips ContainerStatus.Ready based on the
+// StartupProbe/ReadinessProbe declared in the pod spec, so reading this field
+// is equivalent to running the probe ourselves — but via a single cheap GET
+// against the API server instead of a streaming exec session.
+func isPodReady(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Ready {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Manager) waitUntilPodIsRunning(pod *corev1.Pod) error {
 	logz.Host().Info().Msgf("Waiting until %v pod is ready", color.MagentaString(pod.Name))
 
@@ -192,12 +209,18 @@ func (m *Manager) waitUntilPodIsRunning(pod *corev1.Pod) error {
 			return false, fmt.Errorf("interrupted while was waiting for pod readiness")
 		}
 
-		stdout, stderr, err := m.client().ExecInPod("[ -f /tmp/ready ] && echo ready", Namespace, pod.Name, pod.Namespace)
-		if err != nil {
-			logz.Pod().Debug().Msgf("Not ready yet: %v %v", stderr, err.Error())
+		// Read pod readiness from the Kubernetes API (a cheap HTTP GET) instead of
+		// opening a streaming exec session every second. The pod spec already defines
+		// a StartupProbe that checks `/tmp/ready`, so the kubelet is the authoritative
+		// source of readiness and mirrors it into ContainerStatus.Ready.
+		// This dramatically reduces API server load when many helm-in-pod processes
+		// run in parallel (exec opens an SPDY/WebSocket stream per call).
+		latestPod, getErr := m.client().ClientSet().CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if getErr != nil {
+			logz.Pod().Debug().Msgf("Not ready yet: %v", getErr)
 			return false, nil
 		}
-		if strings.Contains(stdout, "ready") {
+		if isPodReady(latestPod) {
 			logz.Host().Debug().Msgf("%v pod is ready", color.CyanString(pod.Name))
 			return true, nil
 		}

--- a/internal/hippod/pod.go
+++ b/internal/hippod/pod.go
@@ -193,8 +193,8 @@ func isPodReady(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
 	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Ready {
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Ready {
 			return true
 		}
 	}

--- a/internal/hippod/pod_test.go
+++ b/internal/hippod/pod_test.go
@@ -55,6 +55,52 @@ var _ = Describe("parseToleration", func() {
 	})
 })
 
+var _ = Describe("isPodReady", func() {
+	It("returns false for a nil pod", func() {
+		Expect(isPodReady(nil)).To(BeFalse())
+	})
+
+	It("returns false when the pod has no container statuses", func() {
+		pod := &corev1.Pod{}
+		Expect(isPodReady(pod)).To(BeFalse())
+	})
+
+	It("returns false when every container is not ready", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "a", Ready: false},
+					{Name: "b", Ready: false},
+				},
+			},
+		}
+		Expect(isPodReady(pod)).To(BeFalse())
+	})
+
+	It("returns true when at least one container is ready", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "a", Ready: false},
+					{Name: "b", Ready: true},
+				},
+			},
+		}
+		Expect(isPodReady(pod)).To(BeTrue())
+	})
+
+	It("returns true when the single container is ready", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "helm-in-pod", Ready: true},
+				},
+			},
+		}
+		Expect(isPodReady(pod)).To(BeTrue())
+	})
+})
+
 var _ = Describe("NodeSelector", func() {
 	It("should handle single node selector", func() {
 		input := map[string]string{"disktype": "ssd"}


### PR DESCRIPTION
## Summary

`waitUntilPodIsRunning` currently opens a streaming `ExecInPod` call every second to run `[ -f /tmp/ready ] && echo ready` inside the pod. Each call goes through a full SPDY/WebSocket upgrade, authentication, and stream teardown on the API server. When many `helm-in-pod` invocations run in parallel this becomes a noticeable load source, and most of the probes actually fail with HTTP 400 while the pod is still starting, which amplifies the cost.

The pod spec in `internal/hippod/spec.go` already declares a `StartupProbe` that runs the exact same `/tmp/ready` check every second from the kubelet side. The kubelet mirrors that result into `ContainerStatus.Ready`, so we can read readiness with one cheap `Pods.Get` instead of opening a new exec session.

## What changed

- `internal/hippod/pod.go`: inside `waitUntilPodIsRunning` replace the per-tick `ExecInPod` with a `CoreV1().Pods(...).Get(...)` and a small helper `isPodReady` that returns true once any container is reported `Ready` by the kubelet.
- The small helper is added in the same file so it can be unit-tested in isolation without touching the manager.
- No changes to the pod spec, no changes to timeouts, poll interval (still 1s), or the overall 5-minute budget. Behaviour from the caller's point of view is identical.

## Why this is the right place to fix it

- The `StartupProbe` in `spec.go` is the authoritative readiness signal. Polling it a second time from the client with `ExecInPod` is pure duplication.
- `ExecInPod` is one of the most expensive calls on the API server: stream upgrade + per-call auth + session cleanup. A `Pods.Get` is a plain HTTP GET.
- Client-side QPS/Burst (default 5/10) is intentionally left untouched. Raising it would let the client push even more requests and make apiserver saturation worse under load; the fix reduces per-call cost instead.

## Measurements

Stress run on a `kind` v1.35 cluster (audit via Prometheus `apiserver_request_total`), running `in-pod exec --copy-repo=false --create-pdb=false -- echo hello` in parallel. All runs succeeded in both cases.

**20 parallel invocations**

| Metric | Before | After | Delta |
|---|---|---|---|
| `pods/exec CONNECT` total | 240 | 80 | **-67%** |
| `pods/exec CONNECT` (400, probe failing) | 124 | 0 | **-100%** |
| `pods GET` | 414 | 696 | +68% (cheap) |

**50 parallel invocations**

| Metric | Before | After | Delta |
|---|---|---|---|
| `pods/exec CONNECT` total | 987 | 200 | **-80%** |
| `pods/exec CONNECT` (400, probe failing) | 694 | 0 | **-100%** |
| `pods GET` | 914 | 1930 | +111% (cheap) |

The ~200 exec calls remaining with the fix are the legitimate ones: copying the wrapper script in, running the user command, signal delivery on shutdown, etc. Everything the readiness poll was doing is gone.

## Tests

- `internal/hippod/pod_test.go`: added unit tests for `isPodReady` covering nil pod, no container statuses, all-not-ready, at-least-one-ready, and single-ready-container.
- `go vet ./...` clean.
- `go test ./...` green.

## Verification suggestions for reviewers

- `go test ./internal/hippod/...`
- In a test cluster: `kind create cluster` and run `in-pod exec --copy-repo=false -- echo hi` in parallel a few dozen times with and without this patch, then diff `apiserver_request_total{resource="pods"}` to reproduce the measurements above.