### PR TITLE
fix: resolve exitCodeMarkerWriter race condition and script.sh timeout fallthrough

### DIFF
--- a/internal/hipembedded/script.sh
+++ b/internal/hipembedded/script.sh
@@ -36,10 +36,16 @@ while [ $MY_TIME -lt $END ]; do
   #echo "Waiting ${SCRIPT_PATH}"
   if [ ! -f "${SCRIPT_PATH}" ]; then
     sleep 1
+    MY_TIME=$((MY_TIME+1))
     continue
   fi
   break
 done
+
+if [ ! -f "${SCRIPT_PATH}" ]; then
+  echo "Timed out waiting for script file ${SCRIPT_PATH} (${TIMEOUT}s)" >&2
+  exit 1
+fi
 
 #echo "#### EXECUTION STARTED ####"
 "${SCRIPT_PATH}" &

--- a/internal/hippod/executor.go
+++ b/internal/hippod/executor.go
@@ -567,11 +567,16 @@ func parseExitCodeFromError(err error) int {
 // exitCodeMarkerWriter wraps an io.Writer and intercepts the exit code marker
 // line emitted by the pod script in copy-from mode. The marker line is consumed
 // (not forwarded to the underlying writer) and the exit code is stored.
+//
+// The writer is safe for concurrent use. It buffers incomplete lines so that a
+// marker split across two Write() calls is still detected correctly.
 type exitCodeMarkerWriter struct {
+	mu         sync.Mutex
 	inner      io.Writer
 	found      bool
 	exitCode   int
 	cancelFunc context.CancelFunc
+	lineBuf    []byte // accumulates bytes until a newline is seen
 }
 
 func newExitCodeMarkerWriter(inner io.Writer, cancel context.CancelFunc) *exitCodeMarkerWriter {
@@ -579,37 +584,73 @@ func newExitCodeMarkerWriter(inner io.Writer, cancel context.CancelFunc) *exitCo
 }
 
 func (w *exitCodeMarkerWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.found {
-		return w.inner.Write(p)
-	}
-	s := string(p)
-	prefix := hipconsts.CopyFromExitCodeMarkerPrefix
-	suffix := hipconsts.CopyFromExitCodeMarkerSuffix
-	if strings.Contains(s, prefix) {
-		// Extract exit code between prefix and suffix
-		_, after, _ := strings.Cut(s, prefix)
-		if codeStr, ok := strings.CutSuffix(after, suffix+"\n"); !ok {
-			codeStr, _ = strings.CutSuffix(after, suffix)
-			after = codeStr
-		} else {
-			after = codeStr
-		}
-		code, err := strconv.Atoi(strings.TrimSpace(after))
-		if err == nil {
-			w.found = true
-			w.exitCode = code
-			w.cancelFunc()
-		}
+		// After marker detected, discard any trailing data from the stream
+		// that may arrive before context cancellation propagates.
 		return len(p), nil
 	}
-	return w.inner.Write(p)
+
+	// Append incoming data to the line buffer and process complete lines.
+	w.lineBuf = append(w.lineBuf, p...)
+	for {
+		idx := bytes.IndexByte(w.lineBuf, '\n')
+		if idx < 0 {
+			// No complete line yet. Check if the buffer already contains the
+			// full marker without a trailing newline (end of stream).
+			if w.tryExtractMarker(string(w.lineBuf)) {
+				return len(p), nil
+			}
+			break
+		}
+		line := string(w.lineBuf[:idx])
+		w.lineBuf = w.lineBuf[idx+1:]
+
+		if w.tryExtractMarker(line) {
+			return len(p), nil
+		}
+		// Not a marker line — forward to the underlying writer.
+		if _, err := w.inner.Write([]byte(line + "\n")); err != nil {
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+// tryExtractMarker checks if line contains the exit code marker. If found,
+// it sets the exit code, marks found=true, and cancels the stream context.
+func (w *exitCodeMarkerWriter) tryExtractMarker(line string) bool {
+	prefix := hipconsts.CopyFromExitCodeMarkerPrefix
+	suffix := hipconsts.CopyFromExitCodeMarkerSuffix
+	if !strings.Contains(line, prefix) {
+		return false
+	}
+	_, after, _ := strings.Cut(line, prefix)
+	codeStr, ok := strings.CutSuffix(after, suffix)
+	if !ok {
+		return false
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(codeStr))
+	if err != nil {
+		return false
+	}
+	w.found = true
+	w.exitCode = code
+	w.cancelFunc()
+	return true
 }
 
 func (w *exitCodeMarkerWriter) Found() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.found
 }
 
 func (w *exitCodeMarkerWriter) ExitCode() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.exitCode
 }
 

--- a/internal/hippod/executor_test.go
+++ b/internal/hippod/executor_test.go
@@ -182,14 +182,15 @@ var _ = Describe("exitCodeMarkerWriter", func() {
 		Expect(w.ExitCode()).To(Equal(137))
 	})
 
-	It("forwards subsequent writes verbatim after marker is found", func() {
+	It("discards subsequent writes after marker is found", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:5###\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(w.Found()).To(BeTrue())
 
 		_, err = w.Write([]byte("trailing output\n"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(inner.String()).To(Equal("trailing output\n"))
+		Expect(inner.String()).To(BeEmpty(),
+			"post-marker data is discarded to prevent garbage on stdout")
 	})
 
 	It("only invokes the cancel function once even on subsequent writes", func() {
@@ -200,29 +201,27 @@ var _ = Describe("exitCodeMarkerWriter", func() {
 		Expect(w.ExitCode()).To(Equal(1), "first marker wins")
 	})
 
-	It("locks in current behavior: marker split across two writes silently loses the exit code", func() {
+	It("handles marker split across two writes via line buffering", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(w.Found()).To(BeFalse())
+		Expect(w.Found()).To(BeFalse(), "no newline yet, line still buffered")
 		Expect(cancelCalls).To(Equal(0))
-		Expect(inner.String()).To(BeEmpty(),
-			"first chunk containing only the prefix is currently consumed but not registered")
+		Expect(inner.String()).To(BeEmpty())
 
 		_, err = w.Write([]byte("42###\n"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(w.Found()).To(BeFalse(),
-			"second chunk has no prefix so the exit code is lost — KNOWN LIMITATION")
-		Expect(inner.String()).To(Equal("42###\n"),
-			"second chunk leaks the suffix as normal output")
+		Expect(w.Found()).To(BeTrue(), "complete line now available, marker detected")
+		Expect(w.ExitCode()).To(Equal(42))
+		Expect(cancelCalls).To(Equal(1))
 	})
 
-	It("locks in current behavior: non-numeric marker value silently consumes the line", func() {
+	It("non-numeric marker value is not registered and line is forwarded", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:abc###\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(w.Found()).To(BeFalse())
 		Expect(cancelCalls).To(Equal(0))
-		Expect(inner.String()).To(BeEmpty(),
-			"line is dropped: not forwarded and not registered — KNOWN LIMITATION")
+		Expect(inner.String()).To(Equal("###HIP_EXIT_CODE:abc###\n"),
+			"invalid marker line is forwarded as normal output")
 	})
 
 	It("trims whitespace around the exit code value", func() {
@@ -240,72 +239,62 @@ var _ = Describe("exitCodeMarkerWriter", func() {
 		Expect(cancelCalls).To(Equal(1))
 	})
 
-	It("locks in current behavior: stdout preceding the marker in the same Write is silently dropped", func() {
-		// In production, kubelet log batching can deliver stdout and the
-		// marker in a single chunk. The writer recognizes the marker and
-		// consumes the entire buffer — preceding user output is lost.
+	It("forwards stdout preceding the marker in the same Write", func() {
 		_, err := w.Write([]byte("important user output\n###HIP_EXIT_CODE:9###\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(w.Found()).To(BeTrue())
 		Expect(w.ExitCode()).To(Equal(9))
-		Expect(inner.String()).To(BeEmpty(),
-			"preceding stdout is dropped — KNOWN LIMITATION")
+		Expect(inner.String()).To(Equal("important user output\n"),
+			"preceding stdout is forwarded correctly")
 	})
 
-	It("locks in current behavior: stdout following the marker in the same Write loses both", func() {
-		// Symmetric to the preceding-stdout case: when the marker has
-		// trailing output in the same Write, CutSuffix fails so the line
-		// is consumed but never registered.
+	It("detects marker and discards stdout following it in the same Write", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:5###\nstdout after marker\n"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(w.Found()).To(BeFalse(),
-			"marker is consumed but not registered when trailing output is present — KNOWN LIMITATION")
-		Expect(cancelCalls).To(Equal(0))
+		Expect(w.Found()).To(BeTrue())
+		Expect(w.ExitCode()).To(Equal(5))
+		Expect(cancelCalls).To(Equal(1))
 		Expect(inner.String()).To(BeEmpty(),
-			"trailing stdout is dropped together with the marker")
+			"trailing stdout after marker is discarded")
 	})
 
-	It("locks in current behavior: two markers in a single Write register neither", func() {
-		// strings.Cut splits on the FIRST prefix, leaving the second marker
-		// embedded in the value — strconv.Atoi then fails on the embedded
-		// '#' characters.
+	It("registers the first marker when two markers appear in a single Write", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:1###\n###HIP_EXIT_CODE:2###\n"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(w.Found()).To(BeFalse(),
-			"two markers in one Write are dropped together — KNOWN LIMITATION")
-		Expect(cancelCalls).To(Equal(0))
-		Expect(inner.String()).To(BeEmpty())
+		Expect(w.Found()).To(BeTrue())
+		Expect(w.ExitCode()).To(Equal(1), "first marker wins")
+		Expect(cancelCalls).To(Equal(1))
+		Expect(inner.String()).To(BeEmpty(),
+			"second marker line is discarded after first is found")
 	})
 
-	It("locks in current behavior: empty marker value is silently dropped", func() {
+	It("empty marker value is not registered and line is forwarded", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:###\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(w.Found()).To(BeFalse(),
-			"empty value fails Atoi → marker not registered — KNOWN LIMITATION")
+			"empty value fails Atoi → marker not registered")
 		Expect(cancelCalls).To(Equal(0))
-		Expect(inner.String()).To(BeEmpty(),
-			"line is still consumed (not forwarded)")
+		Expect(inner.String()).To(Equal("###HIP_EXIT_CODE:###\n"),
+			"invalid marker line is forwarded as normal output")
 	})
 
-	It("locks in current behavior: value that overflows int is silently dropped", func() {
+	It("overflow int value is not registered and line is forwarded", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:99999999999999999999999###\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(w.Found()).To(BeFalse(),
-			"Atoi returns range error → marker not registered — KNOWN LIMITATION")
+			"Atoi returns range error → marker not registered")
 		Expect(cancelCalls).To(Equal(0))
-		Expect(inner.String()).To(BeEmpty())
+		Expect(inner.String()).To(Equal("###HIP_EXIT_CODE:99999999999999999999999###\n"),
+			"invalid marker line is forwarded as normal output")
 	})
 
-	It("locks in current behavior: marker without the trailing ### suffix is still accepted", func() {
-		// The current code falls back to a bare prefix match when both
-		// `suffix+\n` and `suffix` CutSuffix calls return ok=false. The
-		// result is that a malformed line missing the suffix is accepted
-		// as long as the value parses as an int. Behavior is surprising
-		// but matches what the embedded script emits today.
+	It("marker without the trailing ### suffix is rejected and forwarded", func() {
 		_, err := w.Write([]byte("###HIP_EXIT_CODE:7\n"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(w.Found()).To(BeTrue())
-		Expect(w.ExitCode()).To(Equal(7))
-		Expect(cancelCalls).To(Equal(1))
+		Expect(w.Found()).To(BeFalse(),
+			"missing suffix means it's not a valid marker")
+		Expect(cancelCalls).To(Equal(0))
+		Expect(inner.String()).To(Equal("###HIP_EXIT_CODE:7\n"),
+			"invalid marker line is forwarded as normal output")
 	})
 })


### PR DESCRIPTION
## Summary

Fixes two audit findings from the code path review: the `exitCodeMarkerWriter` race condition and the `script.sh` timeout fallthrough.

### Fix 1: `exitCodeMarkerWriter` race condition (executor.go)

**Problem:** The writer had no synchronization and couldn't handle the exit code marker being split across multiple `Write()` calls (valid for `io.Writer`). After finding the marker, trailing data was forwarded to stdout which could include garbage.

**Fix:**
- Added `sync.Mutex` for thread-safe concurrent access
- Added line buffer to accumulate bytes until a newline, so markers split across writes are correctly detected
- After marker is found, all subsequent data is discarded (not forwarded)
- Stricter validation: requires both prefix `###HIP_EXIT_CODE:` and suffix `###`

### Fix 2: `script.sh` timeout fallthrough

**Problem:** If the wait loop timed out (script file never appeared), execution fell through to `"${SCRIPT_PATH}" &` which would fail with "file not found" — but backgrounded, so the user got exit code 127 with no explanation. Also, `MY_TIME` was never incremented inside the loop, so the timeout counter didn't actually advance.

**Fix:**
- Added `MY_TIME=$((MY_TIME+1))` increment inside the loop
- Added explicit `[ ! -f "${SCRIPT_PATH}" ]` check after the loop with a clear error message to stderr and `exit 1`

## Testing

- All 200 existing tests pass
- Race detector clean (`go test -race`)
- Updated 9 tests that documented the old buggy behavior to reflect the new correct behavior
