### PR TITLE
hipretry: fix isTransientError for context.Canceled and add unit tests

### DIFF
--- a/internal/hipretry/retry.go
+++ b/internal/hipretry/retry.go
@@ -98,8 +98,8 @@ func isTransientError(err error) bool {
 	}
 
 	// Common transient network / server errors
+	// Note: context.Canceled is NOT transient — it indicates intentional cancellation.
 	if stderrors.Is(err, context.DeadlineExceeded) ||
-		stderrors.Is(err, context.Canceled) ||
 		strings.Contains(err.Error(), "EOF") ||
 		strings.Contains(err.Error(), "connection reset") ||
 		strings.Contains(err.Error(), "i/o timeout") {

--- a/internal/hipretry/retry_test.go
+++ b/internal/hipretry/retry_test.go
@@ -239,6 +239,29 @@ var _ = Describe("hipretry", func() {
 		})
 	})
 
+	Describe("IsTransientError", func() {
+		It("returns false for context.Canceled (intentional cancellation, no retry)", func() {
+			Expect(IsTransientError(context.Canceled)).To(BeFalse())
+		})
+
+		It("returns true for context.DeadlineExceeded (transient timeout)", func() {
+			Expect(IsTransientError(context.DeadlineExceeded)).To(BeTrue())
+		})
+
+		It("returns true for errors containing EOF string", func() {
+			Expect(IsTransientError(stderrors.New("read tcp: EOF"))).To(BeTrue())
+		})
+
+		It("returns true for errors containing connection reset string", func() {
+			Expect(IsTransientError(stderrors.New("connection reset by peer"))).To(BeTrue())
+		})
+
+		It("returns false for 404 NotFound (permanent error)", func() {
+			err := &apierrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusNotFound}}
+			Expect(IsTransientError(err)).To(BeFalse())
+		})
+	})
+
 	Describe("Unlimited retries mode (MaxAttempts=0)", func() {
 		It("never calls fn when maxAttempts=0", func() {
 			calls := 0


### PR DESCRIPTION
Fixes isTransientError to correctly classify context.Canceled as non-transient and adds unit test coverage.